### PR TITLE
chore: package.json に exports / scripts / files を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,22 @@
   "type": "module",
   "license": "MIT",
   "keywords": ["japanese", "holidays", "japan", "祝日", "typescript"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./light": {
+      "types": "./dist/light.d.ts",
+      "default": "./dist/light.js"
+    }
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run clean && npm run build"
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## 概要

ビルド・公開に必要な設定を `package.json` に追加した。

### exports

```json
{
  ".": {
    "types": "./dist/index.d.ts",
    "default": "./dist/index.js"
  },
  "./light": {
    "types": "./dist/light.d.ts",
    "default": "./dist/light.js"
  }
}
```

### scripts

- `build`: tsc でコンパイル
- `clean`: dist/ を削除
- `prepublishOnly`: publish 前に clean & build を実行

### files

`dist`, `README.md`, `LICENSE` を npm publish 対象に指定。

## 関連 Issue

closes #4

## テスト方法

- `npm run build` でビルドが成功することを確認済み
- `dist/` に `index.js`, `index.d.ts`, `light.js`, `light.d.ts` 等が生成されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)