### PR TITLE
feat: JSON 生成処理の実装

### DIFF
--- a/scripts/generate-holidays.test.ts
+++ b/scripts/generate-holidays.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { parseCsv } from './generate-holidays.ts';
+import {
+  parseCsv,
+  generateHolidayDatesJson,
+  generateHolidayNamesJson,
+} from './generate-holidays.ts';
 
 describe('parseCsv', () => {
   it('基本的な CSV をパースできる', () => {
@@ -57,5 +61,55 @@ describe('parseCsv', () => {
     const csv = '国民の祝日・休日月日,国民の祝日・休日名称\n2025/10/1,都民の日';
     const result = parseCsv(csv);
     assert.strictEqual(result[0].date, '2025-10-01');
+  });
+});
+
+describe('generateHolidayDatesJson', () => {
+  it('空配列の場合は空の JSON 配列を返す', () => {
+    const result = generateHolidayDatesJson([]);
+    assert.strictEqual(result, '[]');
+  });
+
+  it('単一要素の配列で正しい JSON を生成する', () => {
+    const result = generateHolidayDatesJson([{ date: '2025-01-01', name: '元日' }]);
+    assert.strictEqual(result, '["2025-01-01"]');
+  });
+
+  it('複数要素の配列で正しい JSON を生成する', () => {
+    const result = generateHolidayDatesJson([
+      { date: '2025-01-01', name: '元日' },
+      { date: '2025-01-13', name: '成人の日' },
+    ]);
+    assert.strictEqual(result, '["2025-01-01","2025-01-13"]');
+  });
+
+  it('生成された文字列が有効な JSON である', () => {
+    const result = generateHolidayDatesJson([{ date: '2025-01-01', name: '元日' }]);
+    assert.doesNotThrow(() => JSON.parse(result));
+  });
+});
+
+describe('generateHolidayNamesJson', () => {
+  it('空配列の場合は空の JSON オブジェクトを返す', () => {
+    const result = generateHolidayNamesJson([]);
+    assert.strictEqual(result, '{}');
+  });
+
+  it('単一要素の配列で正しい JSON を生成する', () => {
+    const result = generateHolidayNamesJson([{ date: '2025-01-01', name: '元日' }]);
+    assert.strictEqual(result, '{"2025-01-01":"元日"}');
+  });
+
+  it('複数要素の配列で正しい JSON を生成する', () => {
+    const result = generateHolidayNamesJson([
+      { date: '2025-01-01', name: '元日' },
+      { date: '2025-01-13', name: '成人の日' },
+    ]);
+    assert.strictEqual(result, '{"2025-01-01":"元日","2025-01-13":"成人の日"}');
+  });
+
+  it('生成された文字列が有効な JSON である', () => {
+    const result = generateHolidayNamesJson([{ date: '2025-01-01', name: '元日' }]);
+    assert.doesNotThrow(() => JSON.parse(result));
   });
 });

--- a/scripts/generate-holidays.ts
+++ b/scripts/generate-holidays.ts
@@ -43,3 +43,43 @@ export function parseCsv(csvText: string): Holiday[] {
       return { date: formatDate(dateStr), name };
     });
 }
+
+/**
+ * 祝日日付の JSON 文字列を生成する
+ *
+ * @param holidays - 祝日データの配列
+ * @returns JSON 文字列（日付の配列）
+ *
+ * @example
+ * ```typescript
+ * generateHolidayDatesJson([
+ *   { date: '2025-01-01', name: '元日' },
+ *   { date: '2025-01-13', name: '成人の日' },
+ * ]);
+ * // => '["2025-01-01","2025-01-13"]'
+ * ```
+ */
+export function generateHolidayDatesJson(holidays: Holiday[]): string {
+  const dates = holidays.map((h) => h.date);
+  return JSON.stringify(dates);
+}
+
+/**
+ * 祝日名マップの JSON 文字列を生成する
+ *
+ * @param holidays - 祝日データの配列
+ * @returns JSON 文字列（日付をキー、祝日名を値とするオブジェクト）
+ *
+ * @example
+ * ```typescript
+ * generateHolidayNamesJson([
+ *   { date: '2025-01-01', name: '元日' },
+ *   { date: '2025-01-13', name: '成人の日' },
+ * ]);
+ * // => '{"2025-01-01":"元日","2025-01-13":"成人の日"}'
+ * ```
+ */
+export function generateHolidayNamesJson(holidays: Holiday[]): string {
+  const names = Object.fromEntries(holidays.map((h) => [h.date, h.name]));
+  return JSON.stringify(names);
+}


### PR DESCRIPTION
## 概要

Holiday 配列から JSON 文字列を生成する関数を実装した。

- `generateHolidayDatesJson`: 日付の JSON 配列を生成
- `generateHolidayNamesJson`: 日付と祝日名の JSON オブジェクトを生成

## 関連 Issue

closes #20

## テスト方法

```bash
npm test
```