### PR TITLE
feat: 月末・週末の最終営業日を取得する関数を実装

### DIFF
--- a/src/full.test.ts
+++ b/src/full.test.ts
@@ -10,6 +10,8 @@ import {
   getNextBusinessDay,
   getPreviousBusinessDay,
   countBusinessDays,
+  getLastBusinessDayOfMonth,
+  getLastBusinessDayOfWeek,
   getHolidayName,
   getHolidaysInRange,
 } from './full.ts';
@@ -186,5 +188,31 @@ describe('full: countBusinessDays', () => {
   it('Date オブジェクトを受け付ける', () => {
     const result = countBusinessDays(toJstDate('2026-01-05'), toJstDate('2026-01-09'));
     assert.strictEqual(result, 5);
+  });
+});
+
+describe('full: getLastBusinessDayOfMonth', () => {
+  it('月末の最終営業日を返す', () => {
+    // 2026-01-31（土）→ 2026-01-30（金）
+    const result = getLastBusinessDayOfMonth('2026-01-15');
+    assert.strictEqual(result.getTime(), toJstDate('2026-01-30').getTime());
+  });
+
+  it('Date オブジェクトを受け付ける', () => {
+    const result = getLastBusinessDayOfMonth(toJstDate('2026-01-15'));
+    assert.strictEqual(result.getTime(), toJstDate('2026-01-30').getTime());
+  });
+});
+
+describe('full: getLastBusinessDayOfWeek', () => {
+  it('週の最終営業日を返す', () => {
+    // 2026-01-05（月）→ 2026-01-09（金）
+    const result = getLastBusinessDayOfWeek('2026-01-05');
+    assert.strictEqual(result.getTime(), toJstDate('2026-01-09').getTime());
+  });
+
+  it('Date オブジェクトを受け付ける', () => {
+    const result = getLastBusinessDayOfWeek(toJstDate('2026-01-05'));
+    assert.strictEqual(result.getTime(), toJstDate('2026-01-09').getTime());
   });
 });

--- a/src/full.ts
+++ b/src/full.ts
@@ -11,6 +11,8 @@ import { createSubBusinessDays } from './subBusinessDays/index.js';
 import { createGetNextBusinessDay } from './getNextBusinessDay/index.js';
 import { createGetPreviousBusinessDay } from './getPreviousBusinessDay/index.js';
 import { createCountBusinessDays } from './countBusinessDays/index.js';
+import { createGetLastBusinessDayOfMonth } from './getLastBusinessDayOfMonth/index.js';
+import { createGetLastBusinessDayOfWeek } from './getLastBusinessDayOfWeek/index.js';
 import { createGetHolidayName } from './getHolidayName/index.js';
 import { createGetHolidaysInRange } from './getHolidaysInRange/index.js';
 import { isWeekend } from './isWeekend/index.js';
@@ -23,6 +25,8 @@ const subBusinessDays = createSubBusinessDays(holidayNames);
 const getNextBusinessDay = createGetNextBusinessDay(holidayNames);
 const getPreviousBusinessDay = createGetPreviousBusinessDay(holidayNames);
 const countBusinessDays = createCountBusinessDays(holidayNames);
+const getLastBusinessDayOfMonth = createGetLastBusinessDayOfMonth(holidayNames);
+const getLastBusinessDayOfWeek = createGetLastBusinessDayOfWeek(holidayNames);
 const getHolidayName = createGetHolidayName(holidayNames);
 const getHolidaysInRange = createGetHolidaysInRange(holidayNames);
 
@@ -36,6 +40,8 @@ export {
   getNextBusinessDay,
   getPreviousBusinessDay,
   countBusinessDays,
+  getLastBusinessDayOfMonth,
+  getLastBusinessDayOfWeek,
   getHolidayName,
   getHolidaysInRange,
 };

--- a/src/getLastBusinessDayOfMonth/index.test.ts
+++ b/src/getLastBusinessDayOfMonth/index.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createGetLastBusinessDayOfMonth } from './index.js';
+import { toJstDate } from '../_internal/jst.js';
+
+describe('createGetLastBusinessDayOfMonth', () => {
+  // 2025-01-01 元日、2025-01-13 成人の日
+  const mockHolidayDates = new Set(['2025-01-01', '2025-01-13']);
+  const getLastBusinessDayOfMonth = createGetLastBusinessDayOfMonth(mockHolidayDates);
+
+  describe('月末が営業日の場合', () => {
+    it('月末をそのまま返す', () => {
+      // 2025-01-31（金）は営業日
+      const result = getLastBusinessDayOfMonth('2025-01-15');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-31').getTime());
+    });
+  });
+
+  describe('月末が土曜日の場合', () => {
+    it('前の営業日（金曜日）を返す', () => {
+      // 2025-05-31（土）→ 2025-05-30（金）
+      const result = getLastBusinessDayOfMonth('2025-05-15');
+      assert.strictEqual(result.getTime(), toJstDate('2025-05-30').getTime());
+    });
+  });
+
+  describe('月末が日曜日の場合', () => {
+    it('前の営業日（金曜日）を返す', () => {
+      // 2025-08-31（日）→ 2025-08-29（金）
+      const result = getLastBusinessDayOfMonth('2025-08-15');
+      assert.strictEqual(result.getTime(), toJstDate('2025-08-29').getTime());
+    });
+  });
+
+  describe('月末が祝日の場合', () => {
+    it('前の営業日を返す', () => {
+      // 2025-11-30 を祝日に設定
+      const holidaysWithMonthEnd = new Set(['2025-11-30']);
+      const getLastBusinessDayOfMonthWithHoliday =
+        createGetLastBusinessDayOfMonth(holidaysWithMonthEnd);
+      // 2025-11-30（日・祝日）→ 2025-11-28（金）
+      const result = getLastBusinessDayOfMonthWithHoliday('2025-11-15');
+      assert.strictEqual(result.getTime(), toJstDate('2025-11-28').getTime());
+    });
+  });
+
+  describe('月初から取得', () => {
+    it('月初からでも月末の最終営業日を返す', () => {
+      // 2025-01-01 から 2025-01-31（金）を返す
+      const result = getLastBusinessDayOfMonth('2025-01-01');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-31').getTime());
+    });
+  });
+
+  describe('月末から取得', () => {
+    it('月末からでも正しく動作する', () => {
+      // 2025-01-31 から 2025-01-31 を返す
+      const result = getLastBusinessDayOfMonth('2025-01-31');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-31').getTime());
+    });
+  });
+
+  describe('Date オブジェクトの受け付け', () => {
+    it('Date オブジェクトで月末の最終営業日を取得できる', () => {
+      const result = getLastBusinessDayOfMonth(toJstDate('2025-01-15'));
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-31').getTime());
+    });
+  });
+
+  describe('Map をデータソースとして使用', () => {
+    it('Map でも動作する', () => {
+      const holidayNames = new Map([
+        ['2025-01-01', '元日'],
+        ['2025-01-13', '成人の日'],
+      ]);
+      const getLastBusinessDayOfMonthWithMap =
+        createGetLastBusinessDayOfMonth(holidayNames);
+      const result = getLastBusinessDayOfMonthWithMap('2025-01-15');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-31').getTime());
+    });
+  });
+});

--- a/src/getLastBusinessDayOfMonth/index.ts
+++ b/src/getLastBusinessDayOfMonth/index.ts
@@ -1,0 +1,45 @@
+import type { DateInput, DateLookup } from '../types.js';
+import { createIsBusinessDay } from '../isBusinessDay/index.js';
+import { createGetPreviousBusinessDay } from '../getPreviousBusinessDay/index.js';
+import { getEndOfMonth } from '../_internal/getEndOfMonth.js';
+
+/**
+ * getLastBusinessDayOfMonth 関数を生成する
+ *
+ * @param holidayDates - 祝日の日付セット
+ * @returns getLastBusinessDayOfMonth 関数
+ *
+ * @example
+ * ```typescript
+ * const getLastBusinessDayOfMonth = createGetLastBusinessDayOfMonth(holidayDates);
+ * getLastBusinessDayOfMonth('2025-01-15');
+ * // => Date（2025-01-31）
+ * ```
+ */
+export function createGetLastBusinessDayOfMonth(holidayDates: DateLookup) {
+  const isBusinessDay = createIsBusinessDay(holidayDates);
+  const getPreviousBusinessDay = createGetPreviousBusinessDay(holidayDates);
+
+  /**
+   * 指定した日付の月の最終営業日を返す
+   *
+   * @param date - 基準日（Date または YYYY-MM-DD 形式の文字列）
+   * @returns 月の最終営業日の Date オブジェクト
+   *
+   * @example
+   * ```typescript
+   * getLastBusinessDayOfMonth('2025-01-15');
+   * // => Date（2025-01-31）（金曜日）
+   *
+   * getLastBusinessDayOfMonth('2025-05-15');
+   * // => Date（2025-05-30）（土曜なので前日の金曜）
+   * ```
+   */
+  return function getLastBusinessDayOfMonth(date: DateInput): Date {
+    const endOfMonth = getEndOfMonth(date);
+    if (isBusinessDay(endOfMonth)) {
+      return endOfMonth;
+    }
+    return getPreviousBusinessDay(endOfMonth);
+  };
+}

--- a/src/getLastBusinessDayOfWeek/index.test.ts
+++ b/src/getLastBusinessDayOfWeek/index.test.ts
@@ -1,0 +1,91 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createGetLastBusinessDayOfWeek } from './index.js';
+import { toJstDate } from '../_internal/jst.js';
+
+describe('createGetLastBusinessDayOfWeek', () => {
+  // 2025-01-01 元日、2025-01-13 成人の日
+  const mockHolidayDates = new Set(['2025-01-01', '2025-01-13']);
+  const getLastBusinessDayOfWeek = createGetLastBusinessDayOfWeek(mockHolidayDates);
+
+  describe('金曜日が営業日の場合', () => {
+    it('月曜日からその週の金曜日を返す', () => {
+      // 2025-01-06（月）→ 2025-01-10（金）
+      const result = getLastBusinessDayOfWeek('2025-01-06');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-10').getTime());
+    });
+
+    it('水曜日からその週の金曜日を返す', () => {
+      // 2025-01-08（水）→ 2025-01-10（金）
+      const result = getLastBusinessDayOfWeek('2025-01-08');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-10').getTime());
+    });
+
+    it('金曜日からその週の金曜日を返す', () => {
+      // 2025-01-10（金）→ 2025-01-10（金）
+      const result = getLastBusinessDayOfWeek('2025-01-10');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-10').getTime());
+    });
+  });
+
+  describe('土日からの取得', () => {
+    it('土曜日から前の金曜日を返す', () => {
+      // 2025-01-11（土）→ 2025-01-10（金）
+      const result = getLastBusinessDayOfWeek('2025-01-11');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-10').getTime());
+    });
+
+    it('日曜日から次の金曜日を返す', () => {
+      // 2025-01-12（日）→ 2025-01-17（金）
+      const result = getLastBusinessDayOfWeek('2025-01-12');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-17').getTime());
+    });
+  });
+
+  describe('金曜日が祝日の場合', () => {
+    it('前の営業日（木曜日）を返す', () => {
+      // 2025-01-03（金）を祝日に設定
+      const holidaysWithFriday = new Set(['2025-01-03']);
+      const getLastBusinessDayOfWeekWithHoliday =
+        createGetLastBusinessDayOfWeek(holidaysWithFriday);
+      // 2025-01-06（月）の週の金曜は祝日 → 2025-01-02（木）
+      // 注: getEndOfWeek は月曜始まりなので 2025-01-06 から見ると 2025-01-10
+      // 2025-01-03（金）を祝日にしたので、2024-12-30（月）からの週を使う
+      const result = getLastBusinessDayOfWeekWithHoliday('2024-12-30');
+      // 2024-12-30（月）→ 金曜日は 2025-01-03（祝日）→ 2025-01-02（木）
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-02').getTime());
+    });
+  });
+
+  describe('金曜日と木曜日が連続して祝日の場合', () => {
+    it('水曜日を返す', () => {
+      // 2025-01-09（木）、2025-01-10（金）を祝日に設定
+      const holidaysWithThursFri = new Set(['2025-01-09', '2025-01-10']);
+      const getLastBusinessDayOfWeekWithHolidays =
+        createGetLastBusinessDayOfWeek(holidaysWithThursFri);
+      // 2025-01-06（月）→ 金曜 2025-01-10（祝日）→ 木曜 2025-01-09（祝日）→ 2025-01-08（水）
+      const result = getLastBusinessDayOfWeekWithHolidays('2025-01-06');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-08').getTime());
+    });
+  });
+
+  describe('Date オブジェクトの受け付け', () => {
+    it('Date オブジェクトで週の最終営業日を取得できる', () => {
+      const result = getLastBusinessDayOfWeek(toJstDate('2025-01-06'));
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-10').getTime());
+    });
+  });
+
+  describe('Map をデータソースとして使用', () => {
+    it('Map でも動作する', () => {
+      const holidayNames = new Map([
+        ['2025-01-01', '元日'],
+        ['2025-01-13', '成人の日'],
+      ]);
+      const getLastBusinessDayOfWeekWithMap =
+        createGetLastBusinessDayOfWeek(holidayNames);
+      const result = getLastBusinessDayOfWeekWithMap('2025-01-06');
+      assert.strictEqual(result.getTime(), toJstDate('2025-01-10').getTime());
+    });
+  });
+});

--- a/src/getLastBusinessDayOfWeek/index.ts
+++ b/src/getLastBusinessDayOfWeek/index.ts
@@ -1,0 +1,49 @@
+import type { DateInput, DateLookup } from '../types.js';
+import { createIsBusinessDay } from '../isBusinessDay/index.js';
+import { createGetPreviousBusinessDay } from '../getPreviousBusinessDay/index.js';
+import { getEndOfWeek } from '../_internal/getEndOfWeek.js';
+
+/**
+ * getLastBusinessDayOfWeek 関数を生成する
+ *
+ * @param holidayDates - 祝日の日付セット
+ * @returns getLastBusinessDayOfWeek 関数
+ *
+ * @example
+ * ```typescript
+ * const getLastBusinessDayOfWeek = createGetLastBusinessDayOfWeek(holidayDates);
+ * getLastBusinessDayOfWeek('2025-01-06');
+ * // => Date（2025-01-10）
+ * ```
+ */
+export function createGetLastBusinessDayOfWeek(holidayDates: DateLookup) {
+  const isBusinessDay = createIsBusinessDay(holidayDates);
+  const getPreviousBusinessDay = createGetPreviousBusinessDay(holidayDates);
+
+  /**
+   * 指定した日付の週の最終営業日を返す（月〜金の範囲で）
+   *
+   * 週は月曜始まりとして扱い、金曜日を週末日とする。
+   * 金曜日が営業日でない場合は、前の営業日を返す。
+   *
+   * @param date - 基準日（Date または YYYY-MM-DD 形式の文字列）
+   * @returns 週の最終営業日の Date オブジェクト
+   *
+   * @example
+   * ```typescript
+   * getLastBusinessDayOfWeek('2025-01-06');
+   * // => Date（2025-01-10）（金曜日）
+   *
+   * // 金曜日が祝日の場合
+   * getLastBusinessDayOfWeek('2024-12-30');
+   * // => Date（2025-01-02）（金曜が祝日なので木曜）
+   * ```
+   */
+  return function getLastBusinessDayOfWeek(date: DateInput): Date {
+    const endOfWeek = getEndOfWeek(date);
+    if (isBusinessDay(endOfWeek)) {
+      return endOfWeek;
+    }
+    return getPreviousBusinessDay(endOfWeek);
+  };
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,8 @@ import {
   getNextBusinessDay,
   getPreviousBusinessDay,
   countBusinessDays,
+  getLastBusinessDayOfMonth,
+  getLastBusinessDayOfWeek,
 } from './index.ts';
 import { toJstDate } from './_internal/jst.js';
 
@@ -147,5 +149,31 @@ describe('default: countBusinessDays', () => {
   it('Date オブジェクトを受け付ける', () => {
     const result = countBusinessDays(toJstDate('2026-01-05'), toJstDate('2026-01-09'));
     assert.strictEqual(result, 5);
+  });
+});
+
+describe('default: getLastBusinessDayOfMonth', () => {
+  it('月末の最終営業日を返す', () => {
+    // 2026-01-31（土）→ 2026-01-30（金）
+    const result = getLastBusinessDayOfMonth('2026-01-15');
+    assert.strictEqual(result.getTime(), toJstDate('2026-01-30').getTime());
+  });
+
+  it('Date オブジェクトを受け付ける', () => {
+    const result = getLastBusinessDayOfMonth(toJstDate('2026-01-15'));
+    assert.strictEqual(result.getTime(), toJstDate('2026-01-30').getTime());
+  });
+});
+
+describe('default: getLastBusinessDayOfWeek', () => {
+  it('週の最終営業日を返す', () => {
+    // 2026-01-05（月）→ 2026-01-09（金）
+    const result = getLastBusinessDayOfWeek('2026-01-05');
+    assert.strictEqual(result.getTime(), toJstDate('2026-01-09').getTime());
+  });
+
+  it('Date オブジェクトを受け付ける', () => {
+    const result = getLastBusinessDayOfWeek(toJstDate('2026-01-05'));
+    assert.strictEqual(result.getTime(), toJstDate('2026-01-09').getTime());
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { createSubBusinessDays } from './subBusinessDays/index.js';
 import { createGetNextBusinessDay } from './getNextBusinessDay/index.js';
 import { createGetPreviousBusinessDay } from './getPreviousBusinessDay/index.js';
 import { createCountBusinessDays } from './countBusinessDays/index.js';
+import { createGetLastBusinessDayOfMonth } from './getLastBusinessDayOfMonth/index.js';
+import { createGetLastBusinessDayOfWeek } from './getLastBusinessDayOfWeek/index.js';
 import { isWeekend } from './isWeekend/index.js';
 
 const isNationalHoliday = createIsNationalHoliday(holidayDates);
@@ -21,6 +23,8 @@ const subBusinessDays = createSubBusinessDays(holidayDates);
 const getNextBusinessDay = createGetNextBusinessDay(holidayDates);
 const getPreviousBusinessDay = createGetPreviousBusinessDay(holidayDates);
 const countBusinessDays = createCountBusinessDays(holidayDates);
+const getLastBusinessDayOfMonth = createGetLastBusinessDayOfMonth(holidayDates);
+const getLastBusinessDayOfWeek = createGetLastBusinessDayOfWeek(holidayDates);
 
 export {
   isNationalHoliday,
@@ -32,5 +36,7 @@ export {
   getNextBusinessDay,
   getPreviousBusinessDay,
   countBusinessDays,
+  getLastBusinessDayOfMonth,
+  getLastBusinessDayOfWeek,
 };
 export type { DateInput } from './types.js';


### PR DESCRIPTION
## 概要

- Phase 5 として、`getPreviousBusinessDay` と `getEndOfMonth`/`getEndOfWeek` に依存する拡張関数を実装
- `getLastBusinessDayOfMonth`: 指定した月の最終営業日を返す
- `getLastBusinessDayOfWeek`: 指定した週の最終営業日（金曜日または前の営業日）を返す
- 両エントリポイント（`index.ts`, `full.ts`）からエクスポート

## 関連 Issue

closes #38

## テスト方法

```bash
npm test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)