### PR TITLE
chore: implement スキルで Issue コメントも確認するように改良

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -23,13 +23,14 @@ Issue 番号: $ARGUMENTS
 ### 1. Issue の内容を確認
 
 ```bash
-gh issue view $ARGUMENTS
+gh issue view $ARGUMENTS --comments
 ```
 
-Issue から以下を把握する:
+Issue 本文とコメントから以下を把握する:
 - 目的と背景
 - 要件と仕様
 - 受け入れ条件
+- コメントでの追加情報や議論内容
 
 ### 2. ブランチの作成
 


### PR DESCRIPTION
## 概要

`/implement` スキルで Issue の内容を確認する際に、Issue 本文だけでなくコメントも確認するように改良しました。

## 変更内容

- `gh issue view` コマンドに `--comments` オプションを追加
- 把握すべき内容に「コメントでの追加情報や議論内容」を追加

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)