### PR TITLE
fix: 古い moduleResolution でも型定義を解決できるように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "祝日",
     "typescript"
   ],
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## 概要

`moduleResolution: "node"` など古い設定のプロジェクトでも型定義を正しく解決できるように修正しました。

## 問題

`exports` フィールドのみで型定義を指定していたため、`moduleResolution` が `node16`/`nodenext`/`bundler` 以外のプロジェクトで以下のエラーが発生していました：

```
TS2307: Cannot find module '@modelgeek/japanese-holidays' or its corresponding type declarations.
```

## 解決策

トップレベルの `types` フィールドを追加しました。これにより、古い `moduleResolution` でも型定義を見つけられます。

```json
{
  "types": "./dist/index.d.ts",
  "exports": {
    ".": {
      "types": "./dist/index.d.ts",
      "default": "./dist/index.js"
    }
  }
}
```

## テスト方法

別プロジェクトで `moduleResolution: "node"` の設定でインポートして型エラーが出ないことを確認。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)